### PR TITLE
fix: compatibility with new PFIL version

### DIFF
--- a/ndproxy.c
+++ b/ndproxy.c
@@ -66,7 +66,11 @@ static void register_hook() {
   pha.pa_modname = "ndproxy";
   pha.pa_ruleset = NULL;
   pha.pa_rulname = "default-in6";
+#if PFIL_VERSION > 1
+  pha.pa_mbuf_chk = packet;
+#else
   pha.pa_func = packet;
+#endif
   pfh_hook = pfil_add_hook(&pha);
 
   pla.pa_version = PFIL_VERSION;


### PR DESCRIPTION
Since FreeBSD 14 a new PFIL_VERSION has been introduced with a slight different data structure definition for `pfil_hook_args`.

See https://github.com/freebsd/freebsd-src/commit/caf32b260ad46b17a4c1a8ce6383e37ac489f023 for details of the new PFIL_VERSION implementation.

With this fix is possible to compile against FreeBSD 14 kernel, and the pre-processor instruction should assure backwards compatibility.

The patch has been compiled and tested successfully on our production environment recently migrated to FreeBSD 14.
